### PR TITLE
add xmake.lua and support for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ xcuserdata
 *.VC.db
 *.VC.opendb
 ipch
+
+# xmake
+.xmake
+build

--- a/DCE/include/DCE/CacheFile.hpp
+++ b/DCE/include/DCE/CacheFile.hpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <cstdint>
 #include <vector>
+#include <functional>
 #include <DCE/ImageInfo.hpp>
 #include <DCE/MappingInfo.hpp>
 #include <DCE/MachO/File.hpp>

--- a/DCE/include/DCE/MachO/LoadCommand.hpp
+++ b/DCE/include/DCE/MachO/LoadCommand.hpp
@@ -32,6 +32,7 @@
 
 #include <cstdint>
 #include <string>
+#include <memory>
 #include <XS/PIMPL/Object.hpp>
 
 namespace DCE

--- a/DCE/source/CacheFile.cpp
+++ b/DCE/source/CacheFile.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <iostream>
 #include <fstream>
+#include <string.h>
 #include <DCE/CacheFile.hpp>
 #include <DCE/BinaryStream.hpp>
 #include <DCE/MachO/Commands/SegmentCommand.hpp>

--- a/DCE/source/MachO/Commands/SegmentCommand.cpp
+++ b/DCE/source/MachO/Commands/SegmentCommand.cpp
@@ -27,6 +27,7 @@
  * @copyright   (c) 2016, Jean-David Gadina - www.xs-labs.com
  */
 
+#include <string.h>
 #include <DCE/MachO/Commands/SegmentCommand.hpp>
 #include <DCE/MachO/Header.hpp>
 #include <DCE/BinaryStream.hpp>

--- a/DCE/source/MachO/Commands/SegmentCommand64.cpp
+++ b/DCE/source/MachO/Commands/SegmentCommand64.cpp
@@ -26,7 +26,7 @@
  * @file        SegmentCommand64.cpp
  * @copyright   (c) 2016, Jean-David Gadina - www.xs-labs.com
  */
-
+#include <string.h>
 #include <DCE/MachO/Commands/SegmentCommand64.hpp>
 #include <DCE/MachO/Header.hpp>
 #include <DCE/BinaryStream.hpp>

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,12 @@
+set_languages("c++11")
+
+target("DCE")
+    set_kind("static")
+    add_files("DCE/source/**.cpp")
+    add_includedirs("DCE/include", {public = true})
+    add_includedirs("Submodules/PIMPL/PIMPL/include", {public = true})
+
+target("dyld_cache_extract")
+    set_kind("binary")
+    add_deps("DCE")
+    add_files("dyld_cache_extract/*.cpp")


### PR DESCRIPTION
I added xmake.lua to build and use it on linux. we need install [xmake](https://github.com/xmake-io/xmake) first.

Build:

```console
$ xmake
```

Run 

```console
$ xmake run dyld_cache_extract --help
```

Install to system

```console
$ xmake install
$ dyld_cache_extract --help
```